### PR TITLE
Encourage proactive defender pursuit

### DIFF
--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -37,7 +37,9 @@ env:
 
   # 奖励塑形（让 D 更积极接战）
   approach_reward_scale: 0.01   # ↑ 从 0.002 提升
+  closing_reward_scale: 0.008   # 新增：按LOS闭合速度奖励
   kill_reward: 1.0              # ↑ 从 0.25 提升
+  time_penalty: 0.0005          # ↓ 减小时间惩罚
 
 control:
   # 基线控制策略（更偏向主动拦截）


### PR DESCRIPTION
## Summary
- reward defenders for positive line-of-sight closing speeds while damping noisy approach deltas after assignment switches
- make the per-step time penalty configurable and expose closing rate diagnostics to the trainer
- enable the new shaping terms in the default configuration to promote more aggressive guidance

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e3defcd2088322b1bcca4c99656a51