### PR TITLE
Refine defender pursuit model with fixed intercept radius

### DIFF
--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -8,73 +8,63 @@ env:
   dt: 0.1
   max_steps: 600
 
-  # 命中半径
-  t_attack_radius: 8.0
-  d_attack_radius: 24.0
-  t_threat_radius: 60.0      # ↑ 威胁判定提前，留出机动缓冲区（仅放宽命中判定，仍会提前前出）
-  d_threat_radius: 45.0      # ↑ 威胁态下允许更远距离拦截
+  # 命中半径（D 固定截击距离，小于 P 的打击半径）
+  t_attack_radius: 9.0
+  d_attack_radius: 6.5
+  t_threat_radius: 24.0
+  d_threat_radius: 6.5
 
   # 目标初速度（T）
   t_velocity: [10.0, 0.0, 0.0]
 
-  # 攻击者(P)/防守者(D)的速度/加速度上限
-  p_speed_max: 24.0
-  p_accel_max: 6.0
-  d_speed_max: 20.0
-  d_accel_max: 4.0
+  # 攻击者(P)/防守者(D)的速度/加速度上限（确保 D 略弱于 P）
+  p_speed_max: 23.5
+  p_accel_max: 5.2
+  d_speed_max: 18.5
+  d_accel_max: 3.2
 
   # 世界边界 [xmin,xmax], [ymin,ymax], [zmin,zmax]
   world_bounds: [[-1000.0, 1000.0], [-300.0, 300.0], [-150.0, 150.0]]
 
-  # 开局生成参数
+  # 开局生成参数（给予更长前出距离，便于弱机动 D 提前截击）
   spawn:
     t_x_frac: 0.5
-    d_guard_radius: 40.0
-    front_hit_time: 30.0
-    lateral_spread_y: 400.0
-    lateral_spread_z: 300.0
-    min_pp_dist: 300.0
-    min_tp_dist: 120.0
+    d_guard_radius: 36.0
+    front_hit_time: 36.0
+    lateral_spread_y: 320.0
+    lateral_spread_z: 220.0
+    min_pp_dist: 240.0
+    min_tp_dist: 140.0
     spawn_attempts: 200
 
-  # 奖励塑形（让 D 更积极接战）
-  approach_reward_scale: 0.004   # ↓ 让塑形不主导优化
-  closing_reward_scale: 0.003    # ↓ 稍弱的闭合奖励
-  kill_reward: 1.2               # ↑ 适度奖励击杀
-  time_penalty: 0.0008           # ↑ 失败拖延的惩罚
-  failure_penalty: 2.0           # 新增：目标被击中直接-2
-  success_bonus: 2.0             # ↑ 成功护航奖励
-  defender_loss_penalty: 0.2     # 新增：防守方损失惩罚
+  # 奖励塑形（鼓励开局即主动截击并保持效率）
+  approach_reward_scale: 0.003
+  closing_reward_scale: 0.003
+  kill_reward: 1.3
+  time_penalty: 0.0012
+  failure_penalty: 2.2
+  success_bonus: 2.0
+  defender_loss_penalty: 0.25
 
 control:
-  # 基线控制策略（更偏向主动拦截）
-  base_type: attack             # escort -> attack
-
-  # 护航/基础控制的 PD（保留以便切换）
-  base_kp: 0.15
-  base_kd: 0.5
-
-  # 主动拦截控制更“凶”
-  attack_kp: 0.35              # ↑
-  attack_kd: 0.7               # ↑
-  attack_lead_time: 3.0
-  attack_bias: 0.7
-
-  # 行为残差放大与PN导引增益
-  base_alpha: 0.6
+  # 基线控制：使用主动截击模型，并保持部分余量给残差策略
+  base_type: attack
+  base_kp: 0.18
+  base_kd: 0.55
+  attack_kp: 0.4
+  attack_kd: 0.75
+  attack_lead_time: 3.2
+  attack_bias: 0.65
+  base_alpha: 0.85
   residual_gain: 1.0
-  pn_nav_gain: 3.0
-
-  # 管理器周期（更快刷新分配）
-  manager_period: 1            # 2 -> 1
-
-  # 残差模仿触发预算下限（更易触发）
-  imitation_min_budget: 0.02   # 0.10 -> 0.02
+  pn_nav_gain: 3.8
+  manager_period: 1
+  imitation_min_budget: 0.02
 
 matcher:
-  algo: hungarian              # 可选：greedy
-  assign_lock_steps: 8         # 软锁定窗口
-  switch_penalty: 12.0         # 切换成本，抑制频繁抖动
+  algo: hungarian
+  assign_lock_steps: 8
+  switch_penalty: 12.0
 
 train:
   updates: 400


### PR DESCRIPTION
## Summary
- add a proportional-navigation based intercept helper so defenders pursue assignments immediately and remove threat-based kill-radius expansion
- keep the defender kill radius constant in all contacts while updating teacher logic for the new controller
- retune default environment parameters so defenders are weaker than attackers but start with more engagement time and suitable rewards

## Testing
- python -m compileall src/envs/three_d_pursuit.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ede8e2908322b79493e3f8292ed5