### PR TITLE
Enforce sequential hierarchical training workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,110 @@
-# code
+# 3D Pursuit Hierarchical RL Project
+
+This repository contains the hierarchical reinforcement learning stack used in the
+3D pursuit/escort environment.  The workflow is split into two stages:
+
+1. Train the low-level residual controller that outputs acceleration residuals
+   for each defender while the manager follows the built-in rule-based
+   assignment.
+2. Optimise the high-level manager on top of the frozen controller to learn
+   defender-to-attacker assignments.
+
+The sections below list the commands required to run the full project end to
+end.
+
+## 1. Environment setup
+
+```bash
+# (optional) create and activate a virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# install runtime dependencies
+pip install torch numpy pyyaml matplotlib imageio
+```
+
+These packages are sufficient for training, evaluation, log analysis, and GIF
+visualisation.  Installing `scipy` is recommended when using the Hungarian
+matcher implementation.
+
+## 2. Train the residual controller
+
+```bash
+python -m src.train --config src/configs/default.yaml
+```
+
+This command launches PPO training for the defender residual controller while
+the manager runs in `rule` mode (see `manager.mode` in the config).  The script
+writes TensorBoard-style scalars to `runs/default` and stores checkpoints in
+`ckpts/best.pt` (best validation success rate) and `ckpts/latest.pt` (last
+update).  The `best.pt` checkpoint is later reused when training the manager.
+
+## 3. Evaluate controller checkpoints
+
+```bash
+python -m src.validate --config src/configs/default.yaml --episodes 1000
+```
+
+Running the validator reproduces the success rate over a large number of
+episodes for both `best.pt` and `latest.pt`, confirming the quality of the base
+policy before introducing the manager layer.
+
+## 4. Train the high-level manager
+
+```bash
+python -m src.train_manager --config src/configs/default.yaml
+```
+
+Before launching the command, ensure that `manager_train.controller_ckpt`
+points to the trained controller checkpoint (default: `ckpts/best.pt`).  The
+manager script automatically switches the environment to `manager.mode =
+"learned"`, loads the frozen controller to produce residual actions, and
+optimises the categorical actor-critic with PPO.  Logs are saved to
+`runs/default/manager`, and the best weights are written to
+`ckpts/manager_best.pt`.
+
+### Why sequential training?
+
+- **Stability:** learning the low-level residual controller first avoids the
+  non-stationarity that would arise if the manager kept changing assignments
+  while the controller was still exploring.
+- **Sample efficiency:** the manager trains against a strong, fixed controller,
+  so credit assignment focuses on high-level decisions instead of compensating
+  for an under-trained low-level policy.
+- **Modularity:** the trained controller can still be evaluated or deployed
+  with the rule-based manager when needed, while the learned manager can be
+  plugged in later to boost coordination.
+
+## 5. Evaluate the full hierarchical stack
+
+```bash
+python -m src.eval_hierarchical \
+  --config src/configs/default.yaml \
+  --controller-ckpt ckpts/best.pt \
+  --manager-ckpt ckpts/manager_best.pt \
+  --episodes 300
+```
+
+This evaluation script loads both checkpoints, rolls out multiple episodes with
+the manager issuing assignments and the controller producing residual actions,
+and prints the final success rate.
+
+## 6. Inspect training logs
+
+```bash
+python analyze_scalars.py runs/default/scalars.json
+```
+
+The helper script summarises metric trends (returns, success rate, imitation
+loss) and reports whether checkpoints are present.
+
+## 7. Visualise trajectories
+
+```bash
+python -m src.viz_gif --config src/configs/default.yaml \
+  --weights ckpts/best.pt --out runs/viz_best.gif --frames 600 --fps 15
+```
+
+The renderer generates a GIF containing the target, defenders, attackers, and
+assignment lines, allowing qualitative inspection of the learned behaviour.
+

--- a/docs/manager_strategy.md
+++ b/docs/manager_strategy.md
@@ -1,0 +1,50 @@
+# Manager 层强化学习策略改进说明
+
+本次改动围绕“分层强化学习”中的高层 manager 策略展开，核心目标是：
+
+1. 利用深度学习提取战场信息；
+2. 在稳定的低层残差控制器之上，通过强化学习微调协同分配策略；
+3. 最终提升防守方 D 的整体制导率。
+
+以下内容概述主要改动、使用顺序以及训练策略分析。
+
+## 主要改动
+
+1. **高层策略网络实现**：`src/agents/manager.py` 实现了 `ManagerPolicy`，通过多层感知机编码高维战场特征，并输出每名防守者的目标偏好分布，同时内置价值函数，支持 Actor-Critic 更新。
+2. **环境支持学习型分配**：`src/envs/three_d_pursuit.py` 新增 manager 观测、动作掩码及自定义分配接口，可通过 `set_manager_action()` 将策略输出的偏好写回环境，并记录在 `info` 中，便于调试。
+3. **PPO 训练管线**：`src/algos/ppo_manager.py` 与 `src/train_manager.py` 构建了专用的 PPO 回合缓冲、优势估计与训练流程，可独立优化并评估 manager 策略。
+4. **配置与日志**：`src/configs/default.yaml` 的 `manager` 与 `manager_train` 段提供网络宽度、训练超参、评估频率等开关；其中 `manager_train.controller_ckpt` 指定训练 manager 时要加载的低层控制器权重。所有指标通过 `Logger` 写入 `runs/<name>/manager`，便于对比训练前后的制导率变化。
+
+## 推荐使用顺序
+
+1. **先训练低层残差控制器**：保持 `manager.mode: rule`，运行
+   ```bash
+   python -m src.train --config src/configs/default.yaml
+   ```
+   生成 `ckpts/best.pt`（用于后续 manager 训练）以及 `ckpts/latest.pt`。
+2. **固定控制器再训练 manager**：确保 `manager_train.controller_ckpt` 指向上一步得到的权重（默认即 `ckpts/best.pt`），然后执行
+   ```bash
+   python -m src.train_manager --config src/configs/default.yaml
+   ```
+   脚本会加载冻结的残差控制器输出残差动作，仅优化高层分配策略。日志写入 `runs/<name>/manager`，最优权重保存为 `ckpts/manager_best.pt`。
+3. **联合评估分层策略**：运行
+   ```bash
+   python -m src.eval_hierarchical --config src/configs/default.yaml \
+     --controller-ckpt ckpts/best.pt --manager-ckpt ckpts/manager_best.pt --episodes 300
+   ```
+   同时加载两层策略，评估整体制导率表现。
+
+## 训练策略分析
+
+- **为何先规则 manager 再训练 controller？** 低层策略的收敛依赖稳定的分配逻辑。让 manager 保持规则策略可以减少非平稳性，使控制器专注于残差制导和机动能力提升。
+- **为何固定 controller 再训练 manager？** manager 的优化目标是高层协同。如果低层策略同步更新，会导致奖励分布不断漂移、信用分配困难。固定性能达标的控制器后，manager 能专注于学习最优分配。
+- **可以同时训练吗？** 理论上可以，但需要额外的稳定化技巧（多时间尺度更新、共享缓冲等），实现和调参复杂度都更高。本项目选择分阶段训练以保证可复现性和易调试性。
+
+## 预期收益
+
+- **信息提取更充分**：manager 观测整合了成本矩阵、存活状态、威胁等级等信息，深度网络可以学习复杂的协同分配模式。
+- **分配策略可学习**：高层策略输出偏好，再结合匈牙利算法完成冲突消解，减少目标抖动。
+- **指标提升**：训练日志中可观察到成功率、接近速度等指标的提升，为 D 提供更有效的制导支援。
+
+如需进一步分析制导率或成功率变化，可结合 `runs` 目录下的日志文件与其他文档中的流程进行对比评估。
+

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -1,37 +1,99 @@
-# src/agents/manager.py
-# ---------------------------------------
-# （保留）学习型 Manager 的占位实现（本阶段不训练）
-# 说明：第一阶段我们使用规则分配（matcher.assign_targets）。此文件保留以便后续第二阶段启用。
+"""High-level manager policy for hierarchical reinforcement learning."""
+
 from __future__ import annotations
+
+from dataclasses import dataclass
+
 import torch
 import torch.nn as nn
-from dataclasses import dataclass
+
 
 @dataclass
 class ManagerConfig:
+    """Configuration for the manager policy network."""
+
     nD: int
     nP: int
     hidden: int = 256
     device: str = "cpu"
 
+
 class ManagerPolicy(nn.Module):
-    def __init__(self, cfg: ManagerConfig):
+    """Actor-Critic policy that outputs per-defender target preferences."""
+
+    def __init__(self, cfg: ManagerConfig, obs_dim: int):
         super().__init__()
         self.cfg = cfg
-        in_dim = cfg.nD * cfg.nP  # 展平成本矩阵
-        self.net = nn.Sequential(
-            nn.Linear(in_dim, cfg.hidden), nn.ReLU(),
-            nn.Linear(cfg.hidden, cfg.hidden), nn.ReLU(),
-            nn.Linear(cfg.hidden, cfg.nD * cfg.nP)
-        )
+        self.obs_dim = int(obs_dim)
+        action_dim = cfg.nP + 1  # include "no preference" slot
 
-    def forward(self, costs, mask):
-        """
-        costs: (nD, nP), mask: (nD, nP) in {0,1}
-        return logits masked (nD, nP)
-        """
-        x = costs.view(1, -1)  # 简化
-        logits = self.net(x).view(1, self.cfg.nD, self.cfg.nP)
-        # 将无效位置置为 -inf
-        logits = logits + (mask.view(1, self.cfg.nD, self.cfg.nP) - 1.0) * 1e9
-        return logits
+        self.encoder = nn.Sequential(
+            nn.Linear(self.obs_dim, cfg.hidden),
+            nn.ReLU(),
+            nn.Linear(cfg.hidden, cfg.hidden),
+            nn.ReLU(),
+        )
+        self.actor = nn.Linear(cfg.hidden, cfg.nD * action_dim)
+        self.critic = nn.Linear(cfg.hidden, 1)
+
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.kaiming_uniform_(m.weight, a=0.01)
+                nn.init.zeros_(m.bias)
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    def _masked_logits(self, logits: torch.Tensor, action_mask: torch.Tensor | None) -> torch.Tensor:
+        if action_mask is None:
+            return logits
+        mask = action_mask.to(logits.device)
+        # Clamp to avoid log(0) during categorical sampling
+        return logits.masked_fill(mask <= 0, -1e9)
+
+    def act(
+        self,
+        obs: torch.Tensor,
+        action_mask: torch.Tensor | None = None,
+        deterministic: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Sample (or greedily select) defender target indices."""
+
+        if obs.dim() == 1:
+            obs = obs.unsqueeze(0)
+        features = self.encoder(obs)
+        logits = self.actor(features).view(obs.size(0), self.cfg.nD, self.cfg.nP + 1)
+        logits = self._masked_logits(logits, action_mask)
+
+        dist = torch.distributions.Categorical(logits=logits)
+        if deterministic:
+            actions = logits.argmax(dim=-1)
+            logp = dist.log_prob(actions)
+        else:
+            actions = dist.sample()
+            logp = dist.log_prob(actions)
+        logp = logp.sum(dim=-1)
+        value = self.critic(features).squeeze(-1)
+        return actions, logp, value
+
+    def evaluate_actions(
+        self,
+        obs: torch.Tensor,
+        actions: torch.Tensor,
+        action_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if obs.dim() == 1:
+            obs = obs.unsqueeze(0)
+        if actions.dim() == 1:
+            actions = actions.unsqueeze(0)
+
+        features = self.encoder(obs)
+        logits = self.actor(features).view(obs.size(0), self.cfg.nD, self.cfg.nP + 1)
+        logits = self._masked_logits(logits, action_mask)
+
+        dist = torch.distributions.Categorical(logits=logits)
+        logp = dist.log_prob(actions).sum(dim=-1)
+        entropy = dist.entropy().sum(dim=-1)
+        value = self.critic(features).squeeze(-1)
+        return logp, value, entropy

--- a/src/algos/ppo_manager.py
+++ b/src/algos/ppo_manager.py
@@ -1,0 +1,147 @@
+"""PPO implementation tailored for the high-level manager policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .ppo import compute_gae
+
+
+@dataclass
+class ManagerPPOConfig:
+    gamma: float = 0.99
+    gae_lambda: float = 0.95
+    clip_eps: float = 0.2
+    lr: float = 3e-4
+    epochs: int = 4
+    batch_size: int = 128
+    value_coef: float = 0.5
+    entropy_coef: float = 0.01
+    max_grad_norm: float = 0.5
+    target_kl: float = 0.1
+    adv_norm_eps: float = 1e-8
+    device: str = "cpu"
+
+
+class ManagerRolloutBuffer:
+    def __init__(self):
+        self.obs: list[np.ndarray] = []
+        self.actions: list[np.ndarray] = []
+        self.logps: list[float] = []
+        self.values: list[float] = []
+        self.masks: list[np.ndarray] = []
+        self.rewards: list[float] = []
+        self.dones: list[float] = []
+
+    def add(self, obs: np.ndarray, action: np.ndarray, logp: float, value: float, mask: np.ndarray):
+        self.obs.append(obs.astype(np.float32))
+        self.actions.append(action.astype(np.int32))
+        self.logps.append(float(logp))
+        self.values.append(float(value))
+        self.masks.append(mask.astype(np.float32))
+        self.rewards.append(0.0)
+        self.dones.append(0.0)
+
+    def add_reward(self, reward: float, done: bool):
+        if not self.rewards:
+            return
+        self.rewards[-1] += float(reward)
+        self.dones[-1] = float(done)
+
+    def cat(self):
+        if not self.obs:
+            raise RuntimeError("rollout buffer is empty")
+        return {
+            "obs": np.stack(self.obs, axis=0).astype(np.float32),
+            "actions": np.stack(self.actions, axis=0).astype(np.int64),
+            "logps": np.array(self.logps, dtype=np.float32),
+            "values": np.array(self.values, dtype=np.float32),
+            "masks": np.stack(self.masks, axis=0).astype(np.float32),
+            "rewards": np.array(self.rewards, dtype=np.float32),
+            "dones": np.array(self.dones, dtype=np.float32),
+        }
+
+
+def manager_ppo_update(policy, optimizer, data, cfg: ManagerPPOConfig):
+    device = torch.device(cfg.device)
+    obs = torch.from_numpy(data["obs"]).to(device)
+    actions = torch.from_numpy(data["actions"]).to(device)
+    old_logps = torch.from_numpy(data["logps"]).to(device)
+    old_values = torch.from_numpy(data["values"]).to(device)
+    action_masks = torch.from_numpy(data["masks"]).to(device)
+
+    rewards = data["rewards"]
+    dones = data["dones"]
+    adv, returns = compute_gae(rewards, data["values"], dones, cfg.gamma, cfg.gae_lambda)
+    adv_t = torch.from_numpy(adv).float().to(device)
+    returns_t = torch.from_numpy(returns).float().to(device)
+
+    if adv_t.numel() > 1:
+        adv_mean = adv_t.mean()
+        adv_std = adv_t.std()
+        if torch.isfinite(adv_std) and adv_std > cfg.adv_norm_eps:
+            adv_t = (adv_t - adv_mean) / (adv_std + cfg.adv_norm_eps)
+
+    B = obs.shape[0]
+    inds = np.arange(B)
+    n_minibatches = max(1, B // max(1, cfg.batch_size))
+
+    policy_loss = torch.tensor(0.0, device=device)
+    value_loss = torch.tensor(0.0, device=device)
+    entropy_term = torch.tensor(0.0, device=device)
+    last_kl = 0.0
+    kl_stop = False
+
+    for epoch in range(cfg.epochs):
+        np.random.shuffle(inds)
+        for mb_inds in np.array_split(inds, n_minibatches):
+            mb = torch.from_numpy(mb_inds).long().to(device)
+            mb_obs = obs[mb]
+            mb_actions = actions[mb]
+            mb_old_logp = old_logps[mb]
+            mb_old_val = old_values[mb]
+            mb_adv = adv_t[mb]
+            mb_ret = returns_t[mb]
+            mb_mask = action_masks[mb]
+
+            new_logp, v_pred, entropy = policy.evaluate_actions(mb_obs, mb_actions, action_mask=mb_mask)
+            ratio = torch.exp(new_logp - mb_old_logp)
+            surr1 = ratio * mb_adv
+            surr2 = torch.clamp(ratio, 1.0 - cfg.clip_eps, 1.0 + cfg.clip_eps) * mb_adv
+            policy_loss = -torch.min(surr1, surr2).mean()
+
+            value_loss = 0.5 * F.mse_loss(v_pred, mb_ret)
+            entropy_loss = -entropy.mean() * cfg.entropy_coef
+            entropy_term = entropy.mean()
+
+            loss = policy_loss + cfg.value_coef * value_loss + entropy_loss
+
+            optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(policy.parameters(), cfg.max_grad_norm)
+            optimizer.step()
+
+            approx_kl_mb = torch.mean(mb_old_logp - new_logp).detach()
+            last_kl = float(approx_kl_mb.item())
+            if cfg.target_kl > 0 and last_kl > cfg.target_kl:
+                kl_stop = True
+                break
+        if kl_stop:
+            break
+
+    with torch.no_grad():
+        new_logp_all, _, _ = policy.evaluate_actions(obs, actions, action_mask=action_masks)
+        approx_kl = (old_logps - new_logp_all).mean().item()
+
+    return dict(
+        policy_loss=float(policy_loss.item()),
+        value_loss=float(value_loss.item()),
+        entropy=float(entropy_term.item()),
+        approx_kl=float(approx_kl),
+        approx_kl_last=float(last_kl),
+        kl_stop=bool(kl_stop),
+    )

--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -76,6 +76,29 @@ matcher:
   assign_lock_steps: 8         # 软锁定窗口
   switch_penalty: 12.0         # 切换成本，抑制频繁抖动
 
+manager:
+  mode: rule                   # rule | learned
+  hidden: 256                  # 高层网络隐层宽度
+
+manager_train:
+  updates: 300
+  horizon: 256
+  gamma: 0.99
+  gae_lambda: 0.95
+  lr: 0.0003
+  clip_eps: 0.2
+  epochs: 4
+  batch_size: 256
+  value_coef: 0.5
+  entropy_coef: 0.01
+  max_grad_norm: 0.5
+  target_kl: 0.1
+  eval_every: 20
+  eval_episodes: 40
+  final_eval_episodes: 80
+  controller_ckpt: ckpts/best.pt   # 先训练 controller，再加载权重训练 manager
+  controller_deterministic: true   # manager 训练时使用确定性残差动作
+
 train:
   updates: 400
   horizon: 600

--- a/src/eval_hierarchical.py
+++ b/src/eval_hierarchical.py
@@ -1,0 +1,157 @@
+"""Evaluate the full hierarchical stack (manager + controller) over many episodes."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+from pathlib import Path
+
+import torch
+import yaml
+
+from src.agents.controller import ControllerConfig, ControllerPolicy
+from src.agents.manager import ManagerConfig, ManagerPolicy
+from src.envs.three_d_pursuit import ThreeDPursuitEnv
+
+
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def make_env(cfg: dict) -> ThreeDPursuitEnv:
+    return ThreeDPursuitEnv(cfg)
+
+
+def build_controller(cfg: dict, device: torch.device) -> ControllerPolicy:
+    env = make_env(cfg)
+    obs_dim = env.low_obs_dim
+    policy = ControllerPolicy(ControllerConfig(obs_dim=obs_dim, device=str(device))).to(device)
+    return policy
+
+
+def build_manager(cfg: dict, device: torch.device) -> tuple[ManagerPolicy, int, int, int]:
+    env = make_env(cfg)
+    obs_dim = env.get_manager_observation().shape[0]
+    manager_hidden = int(cfg.get("manager", {}).get("hidden", 256))
+    manager_cfg = ManagerConfig(nD=env.nD, nP=env.nP, hidden=manager_hidden, device=str(device))
+    policy = ManagerPolicy(manager_cfg, obs_dim=obs_dim).to(device)
+    return policy, env.nD, env.nP, obs_dim
+
+
+def rollout_episode(
+    make_env_fn,
+    controller: ControllerPolicy,
+    manager: ManagerPolicy,
+    device: torch.device,
+    *,
+    seed: int,
+    deterministic: bool,
+) -> bool:
+    env: ThreeDPursuitEnv = make_env_fn()
+    obs = env.reset(seed=seed)
+    done = False
+    success = False
+    last_reward = 0.0
+
+    while not done:
+        need_update = ((env.t + 1) % max(1, env.manager_period)) == 0
+        if env.manager_mode == "learned" and need_update:
+            with torch.no_grad():
+                mgr_obs = torch.from_numpy(env.get_manager_observation()).float().to(device)
+                mgr_mask = torch.from_numpy(env.get_manager_action_mask()).float().to(device)
+                mgr_action, _, _ = manager.act(mgr_obs, action_mask=mgr_mask, deterministic=deterministic)
+            env.set_manager_action(mgr_action.squeeze(0).cpu().numpy())
+
+        with torch.no_grad():
+            low_obs = torch.from_numpy(obs["low"]).float().to(device)
+            ctrl_action, _, _ = controller.act(low_obs, deterministic=deterministic)
+        obs, reward, done, info = env.step(ctrl_action.cpu().numpy())
+        last_reward = reward
+
+        if info.get("success") or info.get("done_success"):
+            success = True
+            break
+        if int(info.get("attackers_alive", 1)) == 0:
+            success = True
+            break
+
+    if not success and last_reward > 0:
+        success = True
+    return success
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate controller + manager checkpoints together.")
+    parser.add_argument("--config", type=str, default="src/configs/default.yaml", help="Path to YAML config.")
+    parser.add_argument(
+        "--controller-ckpt",
+        type=str,
+        default="ckpts/best.pt",
+        help="Path to the residual controller checkpoint (default: ckpts/best.pt).",
+    )
+    parser.add_argument(
+        "--manager-ckpt",
+        type=str,
+        default="ckpts/manager_best.pt",
+        help="Path to the high-level manager checkpoint (default: ckpts/manager_best.pt).",
+    )
+    parser.add_argument("--episodes", type=int, default=200, help="Number of evaluation episodes (default: 200).")
+    parser.add_argument("--seed", type=int, default=2025, help="Base seed for episode resets (default: 2025).")
+    parser.add_argument(
+        "--stochastic",
+        action="store_true",
+        help="Sample both controller and manager actions stochastically (default: deterministic).",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    cfg_eval = copy.deepcopy(cfg)
+    cfg_eval.setdefault("manager", {})["mode"] = "learned"
+
+    cfg_device = cfg_eval.get("device", "auto")
+    if cfg_device == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(cfg_device)
+
+    controller = build_controller(cfg_eval, device)
+    controller_ckpt = Path(args.controller_ckpt)
+    if not controller_ckpt.exists():
+        raise FileNotFoundError(f"Controller checkpoint not found: {controller_ckpt}")
+    controller.load_state_dict(torch.load(controller_ckpt, map_location=device))
+    controller.eval()
+
+    manager = build_manager(cfg_eval, device)[0]
+    manager_ckpt = Path(args.manager_ckpt)
+    if not manager_ckpt.exists():
+        raise FileNotFoundError(f"Manager checkpoint not found: {manager_ckpt}")
+    manager.load_state_dict(torch.load(manager_ckpt, map_location=device))
+    manager.eval()
+
+    def make_eval_env() -> ThreeDPursuitEnv:
+        return make_env(cfg_eval)
+
+    successes = 0
+    for ep in range(args.episodes):
+        seed = args.seed + ep
+        success = rollout_episode(
+            make_eval_env,
+            controller,
+            manager,
+            device,
+            seed=seed,
+            deterministic=not args.stochastic,
+        )
+        successes += int(success)
+
+    sr = successes / float(max(1, args.episodes))
+    mode = "stochastic" if args.stochastic else "deterministic"
+    print(
+        f"Hierarchical stack success rate over {args.episodes} episodes ({mode} actions): {sr:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/train_manager.py
+++ b/src/train_manager.py
@@ -1,0 +1,222 @@
+"""Training entry for the high-level manager policy."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+import torch
+from torch.optim import Adam
+import yaml
+
+from src.agents.controller import ControllerConfig, ControllerPolicy
+from src.agents.manager import ManagerConfig, ManagerPolicy
+from src.algos.ppo_manager import (
+    ManagerPPOConfig,
+    ManagerRolloutBuffer,
+    manager_ppo_update,
+)
+from src.envs.three_d_pursuit import ThreeDPursuitEnv
+from src.utils.logger import Logger
+
+
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def make_env(cfg: dict) -> ThreeDPursuitEnv:
+    return ThreeDPursuitEnv(cfg)
+
+
+def evaluate_manager(
+    make_env_fn: Callable[[], ThreeDPursuitEnv],
+    policy: ManagerPolicy,
+    device: torch.device,
+    *,
+    controller: Optional[ControllerPolicy] = None,
+    controller_deterministic: bool = True,
+    episodes: int = 50,
+    seed: int = 0,
+) -> float:
+    success = 0
+    policy.eval()
+    with torch.no_grad():
+        for ep in range(episodes):
+            env = make_env_fn()
+            obs_dict = env.reset(seed=seed + ep)
+            done = False
+            while not done:
+                need_update = ((env.t + 1) % max(1, env.manager_period)) == 0
+                if env.manager_mode == "learned" and need_update:
+                    obs = torch.from_numpy(env.get_manager_observation()).float().to(device)
+                    mask = torch.from_numpy(env.get_manager_action_mask()).float().to(device)
+                    action, _, _ = policy.act(obs, action_mask=mask, deterministic=True)
+                    env.set_manager_action(action.squeeze(0).cpu().numpy())
+                if controller is not None:
+                    low_obs = torch.from_numpy(obs_dict["low"]).float().to(device)
+                    ctrl_action, _, _ = controller.act(
+                        low_obs, deterministic=controller_deterministic
+                    )
+                    action_np = ctrl_action.cpu().numpy()
+                else:
+                    action_np = np.zeros((env.nD, 3), dtype=np.float32)
+
+                obs_dict, _, done, info = env.step(action_np)
+            if info.get("success") or info.get("done_success"):
+                success += 1
+    policy.train()
+    return success / max(1, episodes)
+
+
+def main(args):
+    cfg = load_config(args.config)
+    cfg.setdefault("manager", {})
+    cfg["manager"]["mode"] = "learned"
+
+    device_name = cfg.get("device", "auto")
+    if device_name == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(device_name)
+
+    out_dir = cfg.get("manager_out_dir", os.path.join(cfg.get("out_dir", "runs/default"), "manager"))
+    os.makedirs("ckpts", exist_ok=True)
+    logger = Logger(out_dir)
+
+    env = make_env(cfg)
+    obs_dim = env.get_manager_observation().shape[0]
+    manager_hidden = int(cfg.get("manager", {}).get("hidden", 256))
+    manager_cfg = ManagerConfig(nD=env.nD, nP=env.nP, hidden=manager_hidden, device=str(device))
+    policy = ManagerPolicy(manager_cfg, obs_dim=obs_dim).to(device)
+
+    train_cfg_dict = cfg.get("manager_train", {})
+
+    controller_ckpt = train_cfg_dict.get("controller_ckpt") or train_cfg_dict.get(
+        "controller_weights"
+    )
+    controller: ControllerPolicy | None = None
+    if controller_ckpt is not None:
+        controller_path = Path(controller_ckpt)
+        if not controller_path.exists():
+            raise FileNotFoundError(
+                f"Controller checkpoint not found: {controller_path}. "
+                "Train the residual controller first and set manager_train.controller_ckpt."
+            )
+        ctrl_cfg = ControllerConfig(obs_dim=env.low_obs_dim, device=str(device))
+        controller = ControllerPolicy(ctrl_cfg).to(device)
+        state_dict = torch.load(controller_path, map_location=device)
+        controller.load_state_dict(state_dict)
+        controller.eval()
+    else:
+        raise ValueError(
+            "manager_train.controller_ckpt is required so the manager trains on top of the learned controller."
+        )
+
+    controller_deterministic = bool(train_cfg_dict.get("controller_deterministic", True))
+    ppo_cfg = ManagerPPOConfig(
+        gamma=float(train_cfg_dict.get("gamma", 0.99)),
+        gae_lambda=float(train_cfg_dict.get("gae_lambda", 0.95)),
+        clip_eps=float(train_cfg_dict.get("clip_eps", 0.2)),
+        lr=float(train_cfg_dict.get("lr", 3e-4)),
+        epochs=int(train_cfg_dict.get("epochs", 4)),
+        batch_size=int(train_cfg_dict.get("batch_size", 256)),
+        value_coef=float(train_cfg_dict.get("value_coef", 0.5)),
+        entropy_coef=float(train_cfg_dict.get("entropy_coef", 0.01)),
+        max_grad_norm=float(train_cfg_dict.get("max_grad_norm", 0.5)),
+        target_kl=float(train_cfg_dict.get("target_kl", 0.1)),
+        adv_norm_eps=float(train_cfg_dict.get("adv_norm_eps", 1e-8)),
+        device=str(device),
+    )
+    optimizer = Adam(policy.parameters(), lr=ppo_cfg.lr)
+
+    updates = int(train_cfg_dict.get("updates", 300))
+    horizon = int(train_cfg_dict.get("horizon", 256))
+
+    best_sr = 0.0
+    for upd in range(1, updates + 1):
+        buf = ManagerRolloutBuffer()
+        obs = env.reset(seed=cfg.get("seed", 0) + upd)
+        done = False
+        manager_steps = 0
+        ep_reward = 0.0
+
+        while not done and manager_steps < horizon:
+            need_update = ((env.t + 1) % max(1, env.manager_period)) == 0
+            if env.manager_mode == "learned" and need_update:
+                obs_np = env.get_manager_observation()
+                mask_np = env.get_manager_action_mask()
+                obs_t = torch.from_numpy(obs_np).float().to(device)
+                mask_t = torch.from_numpy(mask_np).float().to(device)
+                action_t, logp_t, value_t = policy.act(obs_t, action_mask=mask_t, deterministic=False)
+                action_np = action_t.squeeze(0).cpu().numpy()
+                env.set_manager_action(action_np)
+                buf.add(obs_np, action_np, logp_t.item(), value_t.item(), mask_np)
+                manager_steps += 1
+
+            if controller is not None:
+                with torch.no_grad():
+                    low_obs = torch.from_numpy(obs["low"]).float().to(device)
+                    ctrl_action, _, _ = controller.act(
+                        low_obs, deterministic=controller_deterministic
+                    )
+                action_residual = ctrl_action.cpu().numpy()
+            else:
+                action_residual = np.zeros((env.nD, 3), dtype=np.float32)
+
+            obs, reward, done, _ = env.step(action_residual)
+            buf.add_reward(reward, done)
+            ep_reward += reward
+
+        if not buf.obs:
+            continue
+
+        data = buf.cat()
+        stats = manager_ppo_update(policy, optimizer, data, ppo_cfg)
+
+        logger.log_scalar("train/ep_return", float(ep_reward), upd)
+        logger.log_scalar("loss/policy", stats["policy_loss"], upd)
+        logger.log_scalar("loss/value", stats["value_loss"], upd)
+        logger.log_scalar("loss/entropy", stats["entropy"], upd)
+        logger.log_scalar("debug/approx_kl", stats["approx_kl"], upd)
+        logger.log_scalar("debug/approx_kl_last", stats["approx_kl_last"], upd)
+        logger.log_scalar("debug/kl_stop", 1.0 if stats["kl_stop"] else 0.0, upd)
+
+        if upd % int(train_cfg_dict.get("eval_every", 20)) == 0:
+            sr = evaluate_manager(
+                lambda: make_env(cfg),
+                policy,
+                device,
+                controller=controller,
+                controller_deterministic=controller_deterministic,
+                episodes=int(train_cfg_dict.get("eval_episodes", 50)),
+                seed=2024,
+            )
+            logger.log_scalar("eval/success", float(sr), upd)
+            if sr >= best_sr:
+                best_sr = sr
+                torch.save(policy.state_dict(), os.path.join("ckpts", "manager_best.pt"))
+
+        logger.flush()
+        torch.save(policy.state_dict(), os.path.join("ckpts", "manager_latest.pt"))
+
+    final_sr = evaluate_manager(
+        lambda: make_env(cfg),
+        policy,
+        device,
+        controller=controller,
+        controller_deterministic=controller_deterministic,
+        episodes=int(train_cfg_dict.get("final_eval_episodes", 100)),
+        seed=4242,
+    )
+    print(f"Final manager eval over {int(train_cfg_dict.get('final_eval_episodes', 100))} eps: {final_sr:.3f} | Best: {best_sr:.3f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train high-level manager policy")
+    parser.add_argument("--config", type=str, default="src/configs/default.yaml")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- require manager training to load a trained controller checkpoint so high-level PPO updates run on top of the frozen residual policy
- update the README and manager strategy guide to document the sequential controller-then-manager workflow and explain the rationale for staged training
- expose configuration toggles for the controller checkpoint/inference mode and fix the hierarchical evaluator imports

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e6177221888322813b56f3a2f9b81f