### PR TITLE
Fix manager PPO GAE bootstrap handling

### DIFF
--- a/src/train_manager.py
+++ b/src/train_manager.py
@@ -171,6 +171,20 @@ def main(args):
             buf.add_reward(reward, done)
             ep_reward += reward
 
+        if buf.obs:
+            if done:
+                buf.set_last_value(0.0)
+            else:
+                obs_np = env.get_manager_observation()
+                mask_np = env.get_manager_action_mask()
+                obs_t = torch.from_numpy(obs_np).float().to(device)
+                mask_t = torch.from_numpy(mask_np).float().to(device)
+                with torch.no_grad():
+                    _, _, last_value_t = policy.act(
+                        obs_t, action_mask=mask_t, deterministic=True
+                    )
+                buf.set_last_value(last_value_t.item())
+
         if not buf.obs:
             continue
 


### PR DESCRIPTION
## Summary
- add bootstrap value tracking to the manager rollout buffer
- supply the final value estimate when computing GAE for manager updates
- bootstrap from the environment when an episode truncates without termination

## Testing
- `python -m src.train_manager --config src/configs/default.yaml` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e6316826888322994fc764c3756042