### PR TITLE
Improve manager training stability with teacher mixing

### DIFF
--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -90,8 +90,11 @@ manager_train:
   epochs: 4
   batch_size: 256
   value_coef: 0.5
-  entropy_coef: 0.01
-  teacher_coef: 0.1            # imitation weight toward rule-based assignments
+  entropy_coef: 0.005
+  teacher_coef: 0.4            # stronger imitation weight toward rule-based assignments
+  teacher_mixing_start: 1.0    # probability of executing rule assignment at update 0
+  teacher_mixing_end: 0.2      # anneal toward partial teacher forcing
+  teacher_mixing_decay: 200    # updates over which to anneal mixing probability
   max_grad_norm: 0.5
   target_kl: 0.1
   eval_every: 20


### PR DESCRIPTION
## Summary
- add a scheduled teacher-mixing mechanism so manager rollouts stay close to the rule-based assignment while learning
- log the teacher mixing schedule/usage and ensure rollouts record the actually executed actions for PPO
- retune default manager PPO hyperparameters to emphasise imitation and reduce entropy for more stable success rates

## Testing
- python -m src.train_manager --config src/configs/default.yaml --help *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68e641dd547c8322bec6b0c09aaee143