### PR TITLE
Prevent NaN manager logits

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -47,10 +47,11 @@ class ManagerPolicy(nn.Module):
 
     def _masked_logits(self, logits: torch.Tensor, action_mask: torch.Tensor | None) -> torch.Tensor:
         if action_mask is None:
-            return logits
+            return torch.nan_to_num(logits)
         mask = action_mask.to(logits.device)
         # Clamp to avoid log(0) during categorical sampling
-        return logits.masked_fill(mask <= 0, -1e9)
+        masked = logits.masked_fill(mask <= 0, -1e9)
+        return torch.nan_to_num(masked)
 
     def act(
         self,


### PR DESCRIPTION
## Summary
- clamp the manager assignment cost matrix to the simulation horizon and sanitise the high-level observation so it never emits NaN/Inf values
- guard the manager policy logits against NaN/Inf values after masking

## Testing
- not run (numpy dependency is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6442921bc832290e953c83420485d