### PR TITLE
Add looping turn manoeuvre for target after deploying defenders

### DIFF
--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -17,6 +17,15 @@ env:
   # 目标初速度（T）
   t_velocity: [10.0, 0.0, 0.0]
 
+  # 目标机动：放出 D 后执行环形掉头
+  t_turn:
+    enabled: true
+    delay: 0.0           # s，放出 D 后立即机动
+    radius: 200.0        # m，环形掉头半径
+    direction: left      # left | right，默认向左掉头
+    angle_deg: 180.0     # 掉头角度（默认 180°）
+    axis: [0.0, 0.0, 1.0]
+
   # 攻击者(P)/防守者(D)的速度/加速度上限
   p_speed_max: 24.0
   p_accel_max: 6.0


### PR DESCRIPTION
## Summary
- add configuration to let the target execute a looping turn after defenders are released
- update the 3D pursuit environment so the target follows a configurable circular turn and exposes its dynamic velocity
- expose default looping-turn parameters in the environment configuration

## Testing
- python -m compileall src/envs/three_d_pursuit.py

------
https://chatgpt.com/codex/tasks/task_e_68e711e72fd48322bd6fc67a0ce8fedc